### PR TITLE
对搜索关键字进行URL编码

### DIFF
--- a/searchEngineJump.user.js
+++ b/searchEngineJump.user.js
@@ -2657,7 +2657,7 @@
                 // alert(f);
             } else{
                 //console.log(value);
-                target.href = target.getAttribute('url').replace('%s', value);
+                target.href = target.getAttribute('url').replace('%s', encodeURIComponent(value));
             }
         };
          //获取  POST 的表单的 HTML


### PR DESCRIPTION
目前版本并没有对搜索关键字进行URL编码，导致部分关键词无法正常搜索。比如搜索关键词中包含#、/、&等URL特殊符号时