### PR TITLE
fix(百度)：修复4k分辨率下，搜索条太靠左的问题

### DIFF
--- a/searchEngineJump.user.js
+++ b/searchEngineJump.user.js
@@ -119,12 +119,12 @@
                 fixedTopTarget: "css;#wrapper_wrapper",
                 // fixedTopWhere:"beforeEnd",
                 fixedTopWhere:"beforeBegin",
-                style: '\
+                style:`\
                     margin-top:8px;\
                     margin-bottom: -5px;\
                     z-index: 101;\
-                    margin-left: 144px;\
-                ',
+                    margin-left: ${$('#s_tab_inner').css('padding-left')};\
+                `,
                 style_ACBaidu: '\
                     margin-top: 8px;\
                     margin-bottom: -5px;\


### PR DESCRIPTION
4k分辨率下，百度的搜索条太靠左了，改了下 margin-left